### PR TITLE
[RSDK-10753]   Support multiple RealSense cameras plugged into machine

### DIFF
--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -20,9 +20,6 @@
 namespace viam {
 namespace realsense {
 
-// Global AtomicFrameSet
-AtomicFrameSet GLOBAL_LATEST_FRAMES;
-// align to the color camera's origin when color and depth enabled
 const rs2::align FRAME_ALIGNMENT = RS2_STREAM_COLOR;
 
 // initialize will use the ResourceConfigs to begin the realsense pipeline.
@@ -59,6 +56,14 @@ std::tuple<RealSenseProperties, bool, bool> CameraRealSense::initialize(sdk::Res
     }
     if (width == 0 || height == 0) {
         std::cout << "note: will pick any suitable width and height" << std::endl;
+    }
+    std::string serial_number;
+    if (attrs->count("serial_number") == 1) {
+        std::shared_ptr<sdk::ProtoType> serial_proto = attrs->at("serial_number");
+        auto serial_value = serial_proto->proto_value();
+        if (serial_value.has_string_value()) {
+            serial_number = serial_value.string_value();
+        }
     }
     if (attrs->count("debug") == 1) {
         std::shared_ptr<sdk::ProtoType> debug_proto = attrs->at("debug");
@@ -107,13 +112,14 @@ std::tuple<RealSenseProperties, bool, bool> CameraRealSense::initialize(sdk::Res
     // DeviceProperties context also holds a bool that can stop the thread if device gets
     // disconnected
     std::shared_ptr<DeviceProperties> newDevice = std::make_shared<DeviceProperties>(
-        width, height, disableColor, width, height, disableDepth);
+        width, height, disableColor, width, height, disableDepth, this->latest_frames_);
     device_ = std::move(newDevice);
+    device_->serial_number_to_use = serial_number;
 
     // First start of Pipeline
     rs2::pipeline pipe;
     RealSenseProperties props;
-    std::tie(pipe, props) = startPipeline(disableDepth, width, height, disableColor, width, height);
+    std::tie(pipe, props) = startPipeline(disableDepth, width, height, disableColor, width, height, serial_number);
     // First start of camera thread
     props.sensors = sensors;
     props.mainSensor = sensors[0];
@@ -124,7 +130,7 @@ std::tuple<RealSenseProperties, bool, bool> CameraRealSense::initialize(sdk::Res
                   << std::endl;
     }
     std::promise<void> ready;
-    std::thread cameraThread(frameLoop, pipe, ref(ready), device_, props.depthScaleMm);
+    std::thread cameraThread(frameLoop, pipe, std::ref(ready), device_, props.depthScaleMm, std::ref(this->latest_frames_));
     std::cout << "waiting for camera frame loop thread to be ready..." << std::endl;
     ready.get_future().wait();
     std::cout << "camera frame loop ready!" << std::endl;
@@ -180,9 +186,9 @@ sdk::Camera::raw_image CameraRealSense::get_image(std::string mime_type,
     rs2::frame latestColorFrame;
     std::shared_ptr<std::vector<uint16_t>> latestDepthFrame;
     {
-        std::lock_guard<std::mutex> lock(GLOBAL_LATEST_FRAMES.mutex);
-        latestColorFrame = GLOBAL_LATEST_FRAMES.colorFrame;
-        latestDepthFrame = GLOBAL_LATEST_FRAMES.depthFrame;
+        std::lock_guard<std::mutex> lock(this->latest_frames_.mutex);
+        latestColorFrame = this->latest_frames_.colorFrame;
+        latestDepthFrame = this->latest_frames_.depthFrame;
     }
     std::unique_ptr<sdk::Camera::raw_image> response;
     if (this->props_.mainSensor.compare("color") == 0) {
@@ -261,10 +267,10 @@ sdk::Camera::image_collection CameraRealSense::get_images() {
     std::shared_ptr<std::vector<uint16_t>> latestDepthFrame;
     std::chrono::milliseconds latestTimestamp;
     {
-        std::lock_guard<std::mutex> lock(GLOBAL_LATEST_FRAMES.mutex);
-        latestColorFrame = GLOBAL_LATEST_FRAMES.colorFrame;
-        latestDepthFrame = GLOBAL_LATEST_FRAMES.depthFrame;
-        latestTimestamp = GLOBAL_LATEST_FRAMES.timestamp;
+        std::lock_guard<std::mutex> lock(this->latest_frames_.mutex);
+        latestColorFrame = this->latest_frames_.colorFrame;
+        latestDepthFrame = this->latest_frames_.depthFrame;
+        latestTimestamp = this->latest_frames_.timestamp;
     }
 
     for (const auto& sensor : this->props_.sensors) {
@@ -310,9 +316,9 @@ sdk::Camera::point_cloud CameraRealSense::get_point_cloud(std::string mime_type,
     rs2::points points;
     std::vector<unsigned char> pcdBytes;
     {
-        std::lock_guard<std::mutex> lock(GLOBAL_LATEST_FRAMES.mutex);
-        latestColorFrame = GLOBAL_LATEST_FRAMES.colorFrame;
-        latestDepthFrame = GLOBAL_LATEST_FRAMES.rsDepthFrame;
+        std::lock_guard<std::mutex> lock(this->latest_frames_.mutex);
+        latestColorFrame = this->latest_frames_.colorFrame;
+        latestDepthFrame = this->latest_frames_.rsDepthFrame;
     }
 
     if (latestColorFrame) {
@@ -340,7 +346,8 @@ std::vector<sdk::GeometryConfig> CameraRealSense::get_geometries(const sdk::Attr
 
 // Loop functions
 void frameLoop(rs2::pipeline pipeline, std::promise<void>& ready,
-               std::shared_ptr<DeviceProperties> deviceProps, float depthScaleMm) {
+               std::shared_ptr<DeviceProperties> deviceProps, float depthScaleMm,
+               AtomicFrameSet& instance_latest_frames) {
     bool readyOnce = false;
     {
         std::lock_guard<std::mutex> lock(deviceProps->mutex);
@@ -427,11 +434,11 @@ void frameLoop(rs2::pipeline pipeline, std::promise<void>& ready,
             }
         }
         {
-            std::lock_guard<std::mutex> lock(GLOBAL_LATEST_FRAMES.mutex);
-            GLOBAL_LATEST_FRAMES.colorFrame = frames.get_color_frame();
-            GLOBAL_LATEST_FRAMES.depthFrame = std::move(depthFrameScaled);
-            GLOBAL_LATEST_FRAMES.rsDepthFrame = frames.get_depth_frame();
-            GLOBAL_LATEST_FRAMES.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::lock_guard<std::mutex> lock(instance_latest_frames.mutex);
+            instance_latest_frames.colorFrame = frames.get_color_frame();
+            instance_latest_frames.depthFrame = std::move(depthFrameScaled);
+            instance_latest_frames.rsDepthFrame = frames.get_depth_frame();
+            instance_latest_frames.timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::duration<double, std::milli>(frames.get_timestamp()));
         }
 
@@ -467,18 +474,34 @@ float getDepthScale(rs2::device dev) {
 
 std::tuple<rs2::pipeline, RealSenseProperties> startPipeline(bool disableDepth, int depthWidth,
                                                              int depthHeight, bool disableColor,
-                                                             int colorWidth, int colorHeight) {
+                                                             int colorWidth, int colorHeight,
+                                                             const std::string& serial_number_from_config) {
     rs2::context ctx;
     auto devices = ctx.query_devices();
     if (devices.size() == 0) {
         throw std::runtime_error("no device connected; please connect an Intel RealSense device");
     }
-    rs2::device selected_device = devices.front();
+    rs2::device selected_device;
+    if (serial_number_from_config.empty()) {
+        selected_device = devices.front();
+    } else {
+        for (auto&& dev : devices) {
+            std::string current_serial = dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
+            std::cout << "current_serial: " << current_serial << std::endl;
+            if (current_serial == serial_number_from_config) {
+                selected_device = dev;
+                break;
+            }
+        }
+        if (!selected_device) {
+            throw std::runtime_error("no device with the specified serial number " + serial_number_from_config + " found");
+        }
+    }
 
-    auto serial = selected_device.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
+    auto serial_from_rs2 = selected_device.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
     std::cout << "found device:\n";
     std::cout << "name:      " << selected_device.get_info(RS2_CAMERA_INFO_NAME) << "\n";
-    std::cout << "serial:    " << serial << "\n";
+    std::cout << "serial:    " << serial_from_rs2 << "\n";
     std::cout << "firmware:  " << selected_device.get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION)
               << "\n";
     std::cout << "port:      " << selected_device.get_info(RS2_CAMERA_INFO_PHYSICAL_PORT) << "\n";
@@ -491,7 +514,7 @@ std::tuple<rs2::pipeline, RealSenseProperties> startPipeline(bool disableDepth, 
     }
 
     rs2::config cfg;
-    cfg.enable_device(serial);
+    cfg.enable_device(serial_from_rs2);
 
     if (!disableColor) {
         std::cout << "color width and height from config: (" << colorWidth << ", " << colorHeight
@@ -528,6 +551,7 @@ std::tuple<rs2::pipeline, RealSenseProperties> startPipeline(bool disableDepth, 
 
     RealSenseProperties props;
     props.depthScaleMm = depthScaleMm;
+    props.serial_number = serial_from_rs2;
     if (!disableColor) {
         auto const stream = pipeline.get_active_profile()
                                 .get_stream(RS2_STREAM_COLOR)
@@ -575,32 +599,69 @@ void on_device_reconnect(rs2::event_information& info, rs2::pipeline pipeline,
     if (!device->shouldRun) {
         return;
     }
-    if (info.was_added(info.get_new_devices().front())) {
-        std::cout << "Device was reconnected, restarting pipeline" << std::endl;
-        {
-            // wait until frameLoop is stopped
-            std::unique_lock<std::mutex> lock(device->mutex);
-            device->shouldRun = false;
-            device->cv.wait(lock, [device] { return !(device->isRunning); });
+
+    bool device_found_to_reconnect = false;
+    std::string target_serial_number = device->serial_number_to_use;
+
+    for (auto&& new_dev : info.get_new_devices()) {
+        if (info.was_added(new_dev)) { // assures we're checking a device that was part of the "added" event
+            std::string new_dev_serial = new_dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
+            if (target_serial_number.empty()) {
+                // No specific S/N configured, any new device is a candidate.
+                std::cout << "[on_device_reconnect] A new RealSense device (S/N: " << new_dev_serial
+                          << ") was connected. Attempting to use it as no specific S/N was configured."
+                          << std::endl;
+                device_found_to_reconnect = true;
+                break; 
+            } else {
+                // Specific S/N configured, check for a match.
+                if (new_dev_serial == target_serial_number) {
+                    std::cout << "[on_device_reconnect] Configured device with S/N " << target_serial_number
+                              << " reconnected." << std::endl;
+                    device_found_to_reconnect = true;
+                    break;
+                }
+            }
         }
-        // Find and start the first available device
-        RealSenseProperties props;
-        try {
-            std::tie(pipeline, props) =
-                startPipeline(device->disableDepth, device->depthWidth, device->depthHeight,
-                              device->disableColor, device->colorWidth, device->colorHeight);
-        } catch (const std::exception& e) {
-            std::cout << "caught exception: \"" << e.what() << "\"" << std::endl;
-            return;
-        }
-        // Start the camera std::thread
-        std::promise<void> ready;
-        std::thread cameraThread(frameLoop, pipeline, ref(ready), device, props.depthScaleMm);
-        std::cout << "waiting for camera frame loop thread to be ready..." << std::endl;
-        ready.get_future().wait();
-        std::cout << "camera frame loop ready!" << std::endl;
-        cameraThread.detach();
     }
+
+    if (!device_found_to_reconnect) {
+        return;
+    }
+
+    std::cout << "[on_device_reconnect] Device was reconnected, restarting pipeline" << std::endl;
+    {
+        // wait until frameLoop is stopped
+        std::unique_lock<std::mutex> lock(device->mutex);
+        device->shouldRun = false;
+        device->cv.wait(lock, [device] { return !(device->isRunning); });
+    }
+    
+    RealSenseProperties props;
+    try {
+        std::tie(pipeline, props) =
+            startPipeline(device->disableDepth, device->depthWidth, device->depthHeight,
+                            device->disableColor, device->colorWidth, device->colorHeight,
+                            target_serial_number);
+    } catch (const std::exception& e) {
+        std::cerr << "[on_device_reconnect] Failed to restart pipeline: " << e.what() << std::endl;
+        std::lock_guard<std::mutex> lock(device->mutex);
+        device->isRunning = false; 
+        device->shouldRun = false; 
+        return;
+    }
+
+    // Start the camera std::thread
+    std::promise<void> ready;
+    {
+        std::lock_guard<std::mutex> lock(device->mutex);
+        device->shouldRun = true;
+    }
+    std::thread cameraThread(frameLoop, pipeline, std::ref(ready), device, props.depthScaleMm, std::ref(device->latest_frames_ref));
+    std::cout << "waiting for camera frame loop thread to be ready..." << std::endl;
+    ready.get_future().wait();
+    std::cout << "camera frame loop ready!" << std::endl;
+    cameraThread.detach();
 };
 
 // validate will validate the ResourceConfig. If there is an error, it will throw an exception.
@@ -624,6 +685,18 @@ std::vector<std::string> validate(sdk::ResourceConfig cfg) {
             if (height_num < 0) {
                 throw std::invalid_argument("height_px cannot be negative");
             }
+        }
+    }
+    if (attrs->count("serial_number") == 1) {
+        std::shared_ptr<sdk::ProtoType> serial_proto = attrs->at("serial_number");
+        auto serial_value = serial_proto->proto_value();
+        if (serial_value.has_string_value()) {
+            std::string serial_str = serial_value.string_value();
+            if (serial_str.empty()) {
+                throw std::invalid_argument("serial_number cannot be empty");
+            }
+        } else {
+            throw std::invalid_argument("serial_number must be a string");
         }
     }
     if (attrs->count("sensors") >= 1) {

--- a/src/camera_realsense.hpp
+++ b/src/camera_realsense.hpp
@@ -26,6 +26,14 @@ constexpr char kAPINamespace[] = "viam";
 constexpr char kAPIType[] = "camera";
 constexpr char kAPISubtype[] = "realsense";
 
+struct AtomicFrameSet {
+    std::mutex mutex;
+    rs2::frame colorFrame;
+    std::shared_ptr<std::vector<uint16_t>> depthFrame;
+    rs2::frame rsDepthFrame;
+    std::chrono::milliseconds timestamp;
+};
+
 struct DeviceProperties {
     const uint colorWidth;
     const uint colorHeight;
@@ -33,19 +41,23 @@ struct DeviceProperties {
     const uint depthWidth;
     const uint depthHeight;
     const bool disableDepth;
+    std::string serial_number_to_use;
+    AtomicFrameSet& latest_frames_ref;
     bool shouldRun;
     bool isRunning;
     std::condition_variable cv;
     std::mutex mutex;
-    // DeviceProperties construtor
+    // DeviceProperties constructor
     DeviceProperties(int colorWidth_, int colorHeight_, bool disableColor_, int depthWidth_,
-                     int depthHeight_, bool disableDepth_)
+                     int depthHeight_, bool disableDepth_,
+                     AtomicFrameSet& frames_ref)
         : colorWidth(colorWidth_),
           colorHeight(colorHeight_),
           disableColor(disableColor_),
           depthWidth(depthWidth_),
           depthHeight(depthHeight_),
           disableDepth(disableDepth_),
+          latest_frames_ref(frames_ref),
           shouldRun(true),
           isRunning(false) {}
 };
@@ -68,6 +80,7 @@ struct RealSenseProperties {
     std::string mainSensor;
     std::vector<std::string> sensors;
     bool littleEndianDepth;
+    std::string serial_number;
 };
 
 struct PipelineWithProperties {
@@ -75,23 +88,17 @@ struct PipelineWithProperties {
     RealSenseProperties properties;
 };
 
-struct AtomicFrameSet {
-    std::mutex mutex;
-    rs2::frame colorFrame;
-    std::shared_ptr<std::vector<uint16_t>> depthFrame;
-    rs2::frame rsDepthFrame;
-    std::chrono::milliseconds timestamp;
-};
-
 // The underlying realsense loop functions
 float getDepthScale(rs2::device dev);
 void frameLoop(rs2::pipeline pipeline, std::promise<void>& ready,
-               std::shared_ptr<DeviceProperties> deviceProps, float depthScaleMm);
+               std::shared_ptr<DeviceProperties> deviceProps, float depthScaleMm,
+               AtomicFrameSet& instance_latest_frames);
 void on_device_reconnect(rs2::event_information& info, rs2::pipeline pipeline,
                          std::shared_ptr<DeviceProperties> device);
 std::tuple<rs2::pipeline, RealSenseProperties> startPipeline(bool disableDepth, int depthWidth,
                                                              int depthHeight, bool disableColor,
-                                                             int colorWidth, int colorHeight);
+                                                             int colorWidth, int colorHeight,
+                                                             const std::string& serial_number);
 
 // Module functions
 std::vector<std::string> validate(sdk::ResourceConfig cfg);
@@ -104,6 +111,7 @@ class CameraRealSense : public sdk::Camera, public sdk::Reconfigurable {
     RealSenseProperties props_;
     bool disableColor_;
     bool disableDepth_;
+    AtomicFrameSet latest_frames_;
     std::tuple<RealSenseProperties, bool, bool> initialize(sdk::ResourceConfig cfg);
 
    public:

--- a/test/camera_realsense_test.cpp
+++ b/test/camera_realsense_test.cpp
@@ -27,6 +27,12 @@ TEST(ResourceConfigTest, ValidConfig) {
     sensorListValue.mutable_list_value()->CopyFrom(sensorList);
     // create the attributes field
     (*testConfig.mutable_attributes()->mutable_fields())["sensors"] = sensorListValue;
+
+    // Add a valid serial_number
+    ::google::protobuf::Value serialNumberValue;
+    serialNumberValue.set_string_value("1234567890");
+    (*testConfig.mutable_attributes()->mutable_fields())["serial_number"] = serialNumberValue;
+
     std::vector<std::string> expected;  // the empty string vector is expected
     EXPECT_EQ(vrs::validate(vsdk::ResourceConfig::from_proto(testConfig)), expected);
 }
@@ -65,6 +71,56 @@ TEST(ResourceConfigTest, InvalidSensorsConfig) {
     } catch (...) {
         FAIL() << "Expected std::invalid_argument to catch empty sensors list";
     }
+}
+
+// Test cases for serial_number validation
+TEST(ResourceConfigTest, InvalidSerialNumberConfig) {
+    ::viam::app::v1::ComponentConfig testConfig;
+    testConfig.set_name("my_camera_serial_test");
+    testConfig.set_model("viam:camera:realsense");
+    testConfig.set_api("rdk:component:camera");
+
+    // Construct a valid config with a color sensor
+    ::google::protobuf::Value colorSensor;
+    colorSensor.set_string_value("color");
+    ::google::protobuf::ListValue sensorList;
+    sensorList.add_values()->CopyFrom(colorSensor);
+    ::google::protobuf::Value sensorListValue;
+    sensorListValue.mutable_list_value()->CopyFrom(sensorList);
+    (*testConfig.mutable_attributes()->mutable_fields())["sensors"] = sensorListValue;
+
+    // Test that an empty serial_number string throws an error
+    ::google::protobuf::Value emptySerialNumberValue;
+    emptySerialNumberValue.set_string_value("");
+    (*testConfig.mutable_attributes()->mutable_fields())["serial_number"] = emptySerialNumberValue;
+    try {
+        vrs::validate(vsdk::ResourceConfig::from_proto(testConfig));
+        FAIL() << "Expected std::invalid_argument for empty serial_number";
+    } catch (const std::invalid_argument& e) {
+        EXPECT_EQ(std::string(e.what()), "serial_number cannot be empty");
+    } catch (...) {
+        FAIL() << "Expected std::invalid_argument for empty serial_number, got something else.";
+    }
+
+    // Test that a non-string serial_number throws an error
+    ::google::protobuf::Value nonStringSerialNumberValue;
+    nonStringSerialNumberValue.set_number_value(12345);
+    (*testConfig.mutable_attributes()->mutable_fields())["serial_number"] = nonStringSerialNumberValue;
+    try {
+        vrs::validate(vsdk::ResourceConfig::from_proto(testConfig));
+        FAIL() << "Expected std::invalid_argument for non-string serial_number";
+    } catch (const std::invalid_argument& e) {
+        EXPECT_EQ(std::string(e.what()), "serial_number must be a string");
+    } catch (...) {
+        FAIL() << "Expected std::invalid_argument for non-string serial_number, got something else.";
+    }
+
+    // Test that a valid serial_number (re-check within this specific test case) passes
+    ::google::protobuf::Value validSerialNumberValue;
+    validSerialNumberValue.set_string_value("1234567890");
+    (*testConfig.mutable_attributes()->mutable_fields())["serial_number"] = validSerialNumberValue;
+    std::vector<std::string> expected_deps; // empty vector expected for successful validation
+    EXPECT_EQ(vrs::validate(vsdk::ResourceConfig::from_proto(testConfig)), expected_deps);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
[RSDK-10753](https://viam.atlassian.net/browse/RSDK-10753)

# Manual Tests on my RPI4

```
{
  "components": [
    {
      "name": "irs-1",
      "api": "rdk:component:camera",
      "model": "viam:camera:realsense",
      "attributes": {
        "serial_number": "327122073386",
        "sensors": [
          "color",
          "depth"
        ]
      }
    },
    {
      "name": "irs-2",
      "api": "rdk:component:camera",
      "model": "viam:camera:realsense",
      "attributes": {
        "sensors": [
          "color",
          "depth"
        ],
        "serial_number": "332522076372"
      }
    }
  ],
  "modules": [
    {
      "type": "local",
      "name": "local-realsense-mod",
      "executable_path": "/home/seanyu/viam-camera-realsense-latest-aarch64-multiple-cams-2.AppImage"
    }
  ]
}
```

## Livestreaming two cameras and invoking get point cloud on both
https://www.loom.com/share/6cfbb3659d7a4a91bc10568abe336e1a?sid=52feb50a-f9bb-4721-9dac-4db795a0e46b ✅

## Unplug replug behavior
### Unplug replug camera A
Reconnects ✅
### Unplug camera A, plug camera B with config serial number pointed to camera A
Does not reconnect as expected. We should only reconnect to the camera with the same serial number if configured. ✅
### With no serial number configured, test that reconnect ANY camera works
Yes ✅