### PR TITLE
[RSDK-11039]   RealSense module should detect and report when cameras are plugged in and unplugged

### DIFF
--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -891,8 +891,6 @@ void global_device_changed_handler(rs2::event_information &info) {
             on_device_reconnect(info, device_props);
             {
                 std::lock_guard<std::mutex> lock(rs_devices_mu);
-                VIAM_SDK_LOG(debug) << "[device_changed] adding device to rs_devices: "
-                                    << device_props->active_serial_number;
                 rs_devices[device_props->active_serial_number] =
                     std::make_shared<rs2::device>(rs2_device);
             }

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -831,7 +831,10 @@ void global_device_changed_handler(rs2::event_information &info) {
     for (auto &[serial, dev] : rs_devices) {
         if (info.was_removed(*dev)) {
             VIAM_SDK_LOG(info) << "[device_changed] device removed event for S/N: " << serial;
-            rs_devices.erase(serial);
+            {
+                std::lock_guard<std::mutex> lock(rs_devices_mu);
+                rs_devices.erase(serial);
+            }
         }
     }
 
@@ -1041,10 +1044,9 @@ void start_rs_sdk() {
     }
     {
         std::lock_guard<std::mutex> lock(rs_devices_mu);
-        for (auto &&dev_info_rs2 : devices) {
-            std::string current_serial_number =
-                dev_info_rs2.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
-            rs_devices[current_serial_number] = std::make_shared<rs2::device>(dev_info_rs2);
+        for (auto &&dev : devices) {
+            std::string current_serial_number = dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
+            rs_devices[current_serial_number] = std::make_shared<rs2::device>(dev);
         }
     }
 }

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -656,7 +656,6 @@ float getDepthScale(rs2::device dev) {
 }
 
 std::string printDeviceInfo(rs2::device selected_device) {
-    VIAM_SDK_LOG(info) << "starting pipeline with selected device:";
     std::string serial_from_rs2;
     serial_from_rs2 = selected_device.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
     auto usb_type = std::string(selected_device.get_info(RS2_CAMERA_INFO_USB_TYPE_DESCRIPTOR));
@@ -723,6 +722,7 @@ std::tuple<rs2::pipeline, RealSenseProperties> startPipeline(
                                  target_serial_number);
     }
 
+    VIAM_SDK_LOG(info) << "starting pipeline with selected device:";
     auto serial_from_rs2 = printDeviceInfo(selected_device);
 
     float depthScaleMm = 0.0;
@@ -1037,13 +1037,20 @@ void start_rs_sdk() {
         devices = rs2_ctx.query_devices();
         rs2_ctx.set_devices_changed_callback(global_device_changed_handler);
         if (module_level_debug.load()) {
-            VIAM_SDK_LOG(info) << "global device changed callback registered.";
+            VIAM_SDK_LOG(info) << "[start_rs_sdk] global device changed callback registered.";
         }
     }
     {
         std::lock_guard<std::mutex> lock(rs_devices_mu);
-        for (auto &&dev : devices) {
-            std::string current_serial_number = dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
+        if (devices.size() == 0) {
+            VIAM_SDK_LOG(info) << "[start_rs_sdk] no connected devices detected";
+            return;
+        }
+        for (size_t index = 0; index < devices.size(); ++index) {
+            auto &&dev = devices[index];
+            VIAM_SDK_LOG(info) << "[start_rs_sdk] detected connected device [" << index + 1
+                               << " out of " << devices.size() << "]: ";
+            std::string current_serial_number = printDeviceInfo(dev);
             rs_devices[current_serial_number] = std::make_shared<rs2::device>(dev);
         }
     }

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -828,12 +828,16 @@ void global_device_changed_handler(rs2::event_information &info) {
     }
     VIAM_SDK_LOG(info) << "[device_changed] global device changed event received.";
 
-    for (auto &[serial, rs_dev] : rs_devices) {
-        if (info.was_removed(*rs_dev)) {
-            VIAM_SDK_LOG(info) << "[device_changed] device removed event for S/N: " << serial;
-            {
-                std::lock_guard<std::mutex> lock(rs_devices_mu);
-                rs_devices.erase(serial);
+    {
+        std::lock_guard<std::mutex> lock(rs_devices_mu);
+        // Use iterator-based loop bc we're modifying the container during iteration.
+        for (auto it = rs_devices.begin(); it != rs_devices.end();) {
+            if (info.was_removed(*it->second)) {
+                VIAM_SDK_LOG(info)
+                    << "[device_changed] device removed event for S/N: " << it->first;
+                it = rs_devices.erase(it);
+            } else {
+                ++it;
             }
         }
     }

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -24,8 +24,8 @@ namespace realsense {
 // Build a stringstream and automatically convert to string, all in one line.
 //
 // Global lock to serialize access to module thread state. It protects:
-// 1. RealSense context
-// 2. all objects derived from the RealSense context e.g. rs2 device objects
+// 1. RealSense context (rs2_ctx)
+// 2. pipeline creation and initialization from the context
 // 3. the invariant that there is only one pipeline per device e.g.
 // pipeline.start
 // 4. the registered devices map

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -826,17 +826,17 @@ void global_device_changed_handler(rs2::event_information &info) {
                               "device changed event.";
         return;
     }
+    VIAM_SDK_LOG(info) << "[device_changed] global device changed event received.";
 
     for (auto &[serial, dev] : rs_devices) {
-        if (info.was_removed(dev)) {
+        if (info.was_removed(*dev)) {
             VIAM_SDK_LOG(info) << "[device_changed] device was removed. S/N: " << serial;
             rs_devices.erase(serial);
         }
     }
 
-    std::vector<std::shared_ptr<DeviceProperties>> devices_to_reconnect;
+    std::vector<std::pair<std::shared_ptr<DeviceProperties>, rs2::device>> devices_to_reconnect;
     {
-        VIAM_SDK_LOG(info) << "[device_changed] global device changed event received.";
         std::lock_guard<std::mutex> lock(g_realsense_module_lock);
 
         // TODO: please also handle (indicate that the background frameloop
@@ -879,15 +879,20 @@ void global_device_changed_handler(rs2::event_information &info) {
 
             VIAM_SDK_LOG(info) << "[device_changed] matching active device found for S/N: "
                                << serial_number << ". Scheduling reconnect.";
-            devices_to_reconnect.push_back(device_props_sptr);
+            devices_to_reconnect.emplace_back(device_props_sptr, dev_info);
         }
     }  // g_realsense_module_lock releases
 
-    for (auto &device_props : devices_to_reconnect) {
+    for (auto &[device_props, rs2_device] : devices_to_reconnect) {
         try {
             on_device_reconnect(info, device_props);
-            std::lock_guard<std::mutex> lock(rs_devices_mu);
-            rs_devices.insert({device_props->active_serial_number, device_props->rs_device});
+            {
+                std::lock_guard<std::mutex> lock(rs_devices_mu);
+                VIAM_SDK_LOG(debug) << "[device_changed] adding device to rs_devices: "
+                                    << device_props->active_serial_number;
+                rs_devices[device_props->active_serial_number] =
+                    std::make_shared<rs2::device>(rs2_device);
+            }
         } catch (const std::exception &e) {
             VIAM_SDK_LOG(error) << "[device_changed] failed to reconnect device "
                                 << device_props->active_serial_number << ": " << e.what();

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -828,8 +828,8 @@ void global_device_changed_handler(rs2::event_information &info) {
     }
     VIAM_SDK_LOG(info) << "[device_changed] global device changed event received.";
 
-    for (auto &[serial, dev] : rs_devices) {
-        if (info.was_removed(*dev)) {
+    for (auto &[serial, rs_dev] : rs_devices) {
+        if (info.was_removed(*rs_dev)) {
             VIAM_SDK_LOG(info) << "[device_changed] device removed event for S/N: " << serial;
             {
                 std::lock_guard<std::mutex> lock(rs_devices_mu);
@@ -845,16 +845,16 @@ void global_device_changed_handler(rs2::event_information &info) {
         // TODO: please also handle (indicate that the background frameloop
         // should terminate maybe set shouldrun to false?) unplugs not just
         // replugs (the below logic)
-        for (auto &&dev_info : info.get_new_devices()) {
+        for (auto &&rs_dev : info.get_new_devices()) {
             // assures we're checking a device that was part of the "added"
             // event
-            if (!info.was_added(dev_info)) {
+            if (!info.was_added(rs_dev)) {
                 continue;
             }
 
             std::string serial_number;
             try {
-                serial_number = dev_info.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
+                serial_number = rs_dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
             } catch (const rs2::error &e) {
                 VIAM_SDK_LOG(error) << "[device_changed] failed to get serial "
                                        "number for new device: "
@@ -882,17 +882,17 @@ void global_device_changed_handler(rs2::event_information &info) {
 
             VIAM_SDK_LOG(info) << "[device_changed] matching active device found for S/N: "
                                << serial_number << ". Scheduling reconnect.";
-            devices_to_reconnect.emplace_back(device_props_sptr, dev_info);
+            devices_to_reconnect.emplace_back(device_props_sptr, rs_dev);
         }
     }  // g_realsense_module_lock releases
 
-    for (auto &[device_props, rs2_device] : devices_to_reconnect) {
+    for (auto &[device_props, rs_dev] : devices_to_reconnect) {
         try {
             on_device_reconnect(info, device_props);
             {
                 std::lock_guard<std::mutex> lock(rs_devices_mu);
                 rs_devices[device_props->active_serial_number] =
-                    std::make_shared<rs2::device>(rs2_device);
+                    std::make_shared<rs2::device>(rs_dev);
             }
         } catch (const std::exception &e) {
             VIAM_SDK_LOG(error) << "[device_changed] failed to reconnect device "

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -41,9 +41,9 @@ static rs2::context rs2_ctx;
 // Global registry for configured devices and their properties/pipelines
 static std::map<std::string, std::weak_ptr<DeviceProperties>> registered_devices_;
 
-static std::mutex rs2_devices_mu;
+static std::mutex connected_rs2_devices_mu;
 // Global registry for connected realsense devices
-static std::map<std::string, std::shared_ptr<rs2::device>> rs2_devices;
+static std::map<std::string, std::shared_ptr<rs2::device>> connected_rs2_devices;
 
 // Global flag to signal that the module is shutting down to prevent callback
 // invocation during cleanup
@@ -829,16 +829,19 @@ void global_device_changed_handler(rs2::event_information &info) {
     VIAM_SDK_LOG(info) << "[device_changed] global device changed event received.";
 
     {
-        std::lock_guard<std::mutex> lock(rs2_devices_mu);
-        // Use iterator-based loop bc we're modifying the container during iteration.
-        for (auto it = rs2_devices.begin(); it != rs2_devices.end();) {
-            if (info.was_removed(*it->second)) {
+        std::lock_guard<std::mutex> lock(connected_rs2_devices_mu);
+
+        std::vector<std::string> devices_to_remove;
+        for (const auto &device : connected_rs2_devices) {
+            if (info.was_removed(*device.second)) {
                 VIAM_SDK_LOG(info)
-                    << "[device_changed] device removed event for S/N: " << it->first;
-                it = rs2_devices.erase(it);
-            } else {
-                ++it;
+                    << "[device_changed] device removed event for S/N: " << device.first;
+                devices_to_remove.push_back(device.first);
             }
+        }
+
+        for (const auto &serial : devices_to_remove) {
+            connected_rs2_devices.erase(serial);
         }
     }
 
@@ -894,8 +897,8 @@ void global_device_changed_handler(rs2::event_information &info) {
         try {
             on_device_reconnect(info, device_props);
             {
-                std::lock_guard<std::mutex> lock(rs2_devices_mu);
-                rs2_devices[device_props->active_serial_number] =
+                std::lock_guard<std::mutex> lock(connected_rs2_devices_mu);
+                connected_rs2_devices[device_props->active_serial_number] =
                     std::make_shared<rs2::device>(rs2_dev);
             }
         } catch (const std::exception &e) {
@@ -1045,7 +1048,7 @@ void start_rs2_sdk() {
         }
     }
     {
-        std::lock_guard<std::mutex> lock(rs2_devices_mu);
+        std::lock_guard<std::mutex> lock(connected_rs2_devices_mu);
         if (connected_devices.size() == 0) {
             VIAM_SDK_LOG(info) << "[start_rs2_sdk] no connected devices detected";
             return;
@@ -1055,7 +1058,7 @@ void start_rs2_sdk() {
             VIAM_SDK_LOG(info) << "[start_rs2_sdk] detected connected device [" << index + 1
                                << " out of " << connected_devices.size() << "]: ";
             std::string current_serial_number = printDeviceInfo(rs2_dev);
-            rs2_devices[current_serial_number] = std::make_shared<rs2::device>(rs2_dev);
+            connected_rs2_devices[current_serial_number] = std::make_shared<rs2::device>(rs2_dev);
         }
     }
 }

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -38,12 +38,12 @@ static std::mutex g_realsense_module_lock;
 // module. It is shared across threads; we synchronize accesses when calling
 // context methods concurrently.
 static rs2::context rs2_ctx;
-// Global registry for devices and their properties/pipelines
+// Global registry for configured devices and their properties/pipelines
 static std::map<std::string, std::weak_ptr<DeviceProperties>> registered_devices_;
 
-static std::mutex rs_devices_mu;
-// Global registry for realsense devices
-static std::map<std::string, std::shared_ptr<rs2::device>> rs_devices;
+static std::mutex rs2_devices_mu;
+// Global registry for connected realsense devices
+static std::map<std::string, std::shared_ptr<rs2::device>> rs2_devices;
 
 // Global flag to signal that the module is shutting down to prevent callback
 // invocation during cleanup
@@ -829,13 +829,13 @@ void global_device_changed_handler(rs2::event_information &info) {
     VIAM_SDK_LOG(info) << "[device_changed] global device changed event received.";
 
     {
-        std::lock_guard<std::mutex> lock(rs_devices_mu);
+        std::lock_guard<std::mutex> lock(rs2_devices_mu);
         // Use iterator-based loop bc we're modifying the container during iteration.
-        for (auto it = rs_devices.begin(); it != rs_devices.end();) {
+        for (auto it = rs2_devices.begin(); it != rs2_devices.end();) {
             if (info.was_removed(*it->second)) {
                 VIAM_SDK_LOG(info)
                     << "[device_changed] device removed event for S/N: " << it->first;
-                it = rs_devices.erase(it);
+                it = rs2_devices.erase(it);
             } else {
                 ++it;
             }
@@ -849,16 +849,16 @@ void global_device_changed_handler(rs2::event_information &info) {
         // TODO: please also handle (indicate that the background frameloop
         // should terminate maybe set shouldrun to false?) unplugs not just
         // replugs (the below logic)
-        for (auto &&rs_dev : info.get_new_devices()) {
+        for (auto &&rs2_dev : info.get_new_devices()) {
             // assures we're checking a device that was part of the "added"
             // event
-            if (!info.was_added(rs_dev)) {
+            if (!info.was_added(rs2_dev)) {
                 continue;
             }
 
             std::string serial_number;
             try {
-                serial_number = rs_dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
+                serial_number = rs2_dev.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
             } catch (const rs2::error &e) {
                 VIAM_SDK_LOG(error) << "[device_changed] failed to get serial "
                                        "number for new device: "
@@ -886,17 +886,17 @@ void global_device_changed_handler(rs2::event_information &info) {
 
             VIAM_SDK_LOG(info) << "[device_changed] matching active device found for S/N: "
                                << serial_number << ". Scheduling reconnect.";
-            devices_to_reconnect.emplace_back(device_props_sptr, rs_dev);
+            devices_to_reconnect.emplace_back(device_props_sptr, rs2_dev);
         }
     }  // g_realsense_module_lock releases
 
-    for (auto &[device_props, rs_dev] : devices_to_reconnect) {
+    for (auto &[device_props, rs2_dev] : devices_to_reconnect) {
         try {
             on_device_reconnect(info, device_props);
             {
-                std::lock_guard<std::mutex> lock(rs_devices_mu);
-                rs_devices[device_props->active_serial_number] =
-                    std::make_shared<rs2::device>(rs_dev);
+                std::lock_guard<std::mutex> lock(rs2_devices_mu);
+                rs2_devices[device_props->active_serial_number] =
+                    std::make_shared<rs2::device>(rs2_dev);
             }
         } catch (const std::exception &e) {
             VIAM_SDK_LOG(error) << "[device_changed] failed to reconnect device "
@@ -1034,28 +1034,28 @@ std::vector<std::string> validate(sdk::ResourceConfig cfg) {
     }
 }
 
-void start_rs_sdk() {
-    rs2::device_list devices;
+void start_rs2_sdk() {
+    rs2::device_list connected_devices;
     {
         std::lock_guard<std::mutex> lock(g_realsense_module_lock);
-        devices = rs2_ctx.query_devices();
+        connected_devices = rs2_ctx.query_devices();
         rs2_ctx.set_devices_changed_callback(global_device_changed_handler);
         if (module_level_debug.load()) {
-            VIAM_SDK_LOG(info) << "[start_rs_sdk] global device changed callback registered.";
+            VIAM_SDK_LOG(info) << "[start_rs2_sdk] global device changed callback registered.";
         }
     }
     {
-        std::lock_guard<std::mutex> lock(rs_devices_mu);
-        if (devices.size() == 0) {
-            VIAM_SDK_LOG(info) << "[start_rs_sdk] no connected devices detected";
+        std::lock_guard<std::mutex> lock(rs2_devices_mu);
+        if (connected_devices.size() == 0) {
+            VIAM_SDK_LOG(info) << "[start_rs2_sdk] no connected devices detected";
             return;
         }
-        for (size_t index = 0; index < devices.size(); ++index) {
-            auto &&dev = devices[index];
-            VIAM_SDK_LOG(info) << "[start_rs_sdk] detected connected device [" << index + 1
-                               << " out of " << devices.size() << "]: ";
-            std::string current_serial_number = printDeviceInfo(dev);
-            rs_devices[current_serial_number] = std::make_shared<rs2::device>(dev);
+        for (size_t index = 0; index < connected_devices.size(); ++index) {
+            auto &&rs2_dev = connected_devices[index];
+            VIAM_SDK_LOG(info) << "[start_rs2_sdk] detected connected device [" << index + 1
+                               << " out of " << connected_devices.size() << "]: ";
+            std::string current_serial_number = printDeviceInfo(rs2_dev);
+            rs2_devices[current_serial_number] = std::make_shared<rs2::device>(rs2_dev);
         }
     }
 }
@@ -1068,7 +1068,7 @@ int serve(int argc, char **argv) {
         }
     }
 
-    start_rs_sdk();
+    start_rs2_sdk();
 
     std::shared_ptr<sdk::ModelRegistration> mr = std::make_shared<sdk::ModelRegistration>(
         sdk::API::get<sdk::Camera>(), sdk::Model{kAPINamespace, kAPIType, kAPISubtype},

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -41,6 +41,10 @@ static rs2::context rs2_ctx;
 // Global registry for devices and their properties/pipelines
 static std::map<std::string, std::weak_ptr<DeviceProperties>> registered_devices_;
 
+static std::mutex rs_devices_mu;
+// Global registry for realsense devices
+static std::map<std::string, std::shared_ptr<rs2::device>> rs_devices;
+
 // Global flag to signal that the module is shutting down to prevent callback
 // invocation during cleanup
 // NOTE: Nick S: This is an imcomplete solution. We don't confirm that we
@@ -823,6 +827,13 @@ void global_device_changed_handler(rs2::event_information &info) {
         return;
     }
 
+    for (auto &[serial, dev] : rs_devices) {
+        if (info.was_removed(dev)) {
+            VIAM_SDK_LOG(info) << "[device_changed] device was removed. S/N: " << serial;
+            rs_devices.erase(serial);
+        }
+    }
+
     std::vector<std::shared_ptr<DeviceProperties>> devices_to_reconnect;
     {
         VIAM_SDK_LOG(info) << "[device_changed] global device changed event received.";
@@ -875,6 +886,8 @@ void global_device_changed_handler(rs2::event_information &info) {
     for (auto &device_props : devices_to_reconnect) {
         try {
             on_device_reconnect(info, device_props);
+            std::lock_guard<std::mutex> lock(rs_devices_mu);
+            rs_devices.insert({device_props->active_serial_number, device_props->rs_device});
         } catch (const std::exception &e) {
             VIAM_SDK_LOG(error) << "[device_changed] failed to reconnect device "
                                 << device_props->active_serial_number << ": " << e.what();
@@ -1011,6 +1024,26 @@ std::vector<std::string> validate(sdk::ResourceConfig cfg) {
     }
 }
 
+void start_rs_sdk() {
+    rs2::device_list devices;
+    {
+        std::lock_guard<std::mutex> lock(g_realsense_module_lock);
+        devices = rs2_ctx.query_devices();
+        rs2_ctx.set_devices_changed_callback(global_device_changed_handler);
+        if (module_level_debug.load()) {
+            VIAM_SDK_LOG(info) << "global device changed callback registered.";
+        }
+    }
+    {
+        std::lock_guard<std::mutex> lock(rs_devices_mu);
+        for (auto &&dev_info_rs2 : devices) {
+            std::string current_serial_number =
+                dev_info_rs2.get_info(RS2_CAMERA_INFO_SERIAL_NUMBER);
+            rs_devices[current_serial_number] = std::make_shared<rs2::device>(dev_info_rs2);
+        }
+    }
+}
+
 int serve(int argc, char **argv) {
     for (size_t i = 0; i < argc; i++) {
         if (std::string(argv[i]) == "--log-level=debug") {
@@ -1018,6 +1051,9 @@ int serve(int argc, char **argv) {
             rs2::log_to_console(RS2_LOG_SEVERITY_DEBUG);
         }
     }
+
+    start_rs_sdk();
+
     std::shared_ptr<sdk::ModelRegistration> mr = std::make_shared<sdk::ModelRegistration>(
         sdk::API::get<sdk::Camera>(), sdk::Model{kAPINamespace, kAPIType, kAPISubtype},
         [](sdk::Dependencies deps, sdk::ResourceConfig cfg) -> std::shared_ptr<sdk::Resource> {
@@ -1027,14 +1063,6 @@ int serve(int argc, char **argv) {
 
     std::vector<std::shared_ptr<sdk::ModelRegistration>> mrs = {mr};
     auto module_service = std::make_shared<sdk::ModuleService>(argc, argv, mrs);
-
-    {
-        std::lock_guard<std::mutex> lock(g_realsense_module_lock);
-        rs2_ctx.set_devices_changed_callback(global_device_changed_handler);
-        if (module_level_debug.load()) {
-            VIAM_SDK_LOG(info) << "global device changed callback registered.";
-        }
-    }
 
     module_service->serve();
     module_shutting_down.store(true);

--- a/src/camera_realsense.cpp
+++ b/src/camera_realsense.cpp
@@ -830,7 +830,7 @@ void global_device_changed_handler(rs2::event_information &info) {
 
     for (auto &[serial, dev] : rs_devices) {
         if (info.was_removed(*dev)) {
-            VIAM_SDK_LOG(info) << "[device_changed] device was removed. S/N: " << serial;
+            VIAM_SDK_LOG(info) << "[device_changed] device removed event for S/N: " << serial;
             rs_devices.erase(serial);
         }
     }


### PR DESCRIPTION
[RSDK-11039](https://viam.atlassian.net/browse/RSDK-11039)

[RSDK-11039]: https://viam.atlassian.net/browse/RSDK-11039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

# Manual Testing

## No cameras plugged in at startup
`6/26/2025, 3:25:14 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 15:25:14: [Viam C++ SDK] <info> [src/camera_realsense.cpp:1046] [start_rs2_sdk] no connected devices detected`

## 1 camera plugged in at startup
```
6/26/2025, 3:26:47 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 15:26:47: [Viam C++ SDK] <info> [src/camera_realsense.cpp:681] usb type: 3.2

6/26/2025, 3:26:47 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 15:26:47: [Viam C++ SDK] <info> [src/camera_realsense.cpp:677] port: /sys/devices/pci0000:00/0000:00:0d.0/usb4/4-1/4-1:1.0/video4linux/video0

6/26/2025, 3:26:47 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 15:26:47: [Viam C++ SDK] <info> [src/camera_realsense.cpp:670] recommended firmware: 5.16.0.1

6/26/2025, 3:26:47 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 15:26:47: [Viam C++ SDK] <info> [src/camera_realsense.cpp:669] firmware: 5.16.0.1

6/26/2025, 3:26:47 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 15:26:47: [Viam C++ SDK] <info> [src/camera_realsense.cpp:667] serial: 332522076372

6/26/2025, 3:26:47 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 15:26:47: [Viam C++ SDK] <info> [src/camera_realsense.cpp:666] name: Intel RealSense D435

6/26/2025, 3:26:47 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 15:26:47: [Viam C++ SDK] <info> [src/camera_realsense.cpp:1051] [start_rs2_sdk] detected connected device [1 out of 1]:
```

## 2 cameras plugged in at startup
```
6/26/2025, 4:47:55 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 16:47:55: [Viam C++ SDK] <info> [src/camera_realsense.cpp:681] usb type: 3.2

6/26/2025, 4:47:55 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 16:47:55: [Viam C++ SDK] <info> [src/camera_realsense.cpp:677] port: /sys/devices/pci0000:00/0000:00:0d.0/usb4/4-3/4-3.3/4-3.3:1.0/video4linux/video8

6/26/2025, 4:47:55 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 16:47:55: [Viam C++ SDK] <info> [src/camera_realsense.cpp:670] recommended firmware: 5.16.0.1

6/26/2025, 4:47:55 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 16:47:55: [Viam C++ SDK] <info> [src/camera_realsense.cpp:669] firmware: 5.16.0.1

6/26/2025, 4:47:55 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 16:47:55: [Viam C++ SDK] <info> [src/camera_realsense.cpp:667] serial: 233522076211

6/26/2025, 4:47:55 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 16:47:55: [Viam C++ SDK] <info> [src/camera_realsense.cpp:666] name: Intel RealSense D435I

6/26/2025, 4:47:55 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 16:47:55: [Viam C++ SDK] <info> [src/camera_realsense.cpp:1055] [start_rs2_sdk] detected connected device [2 out of 2]:

6/26/2025, 4:47:55 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 16:47:55: [Viam C++ SDK] <info> [src/camera_realsense.cpp:681] usb type: 3.2

6/26/2025, 4:47:55 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 16:47:55: [Viam C++ SDK] <info> [src/camera_realsense.cpp:677] port: /sys/devices/pci0000:00/0000:00:0d.0/usb4/4-1/4-1:1.0/video4linux/video0

6/26/2025, 4:47:55 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 16:47:55: [Viam C++ SDK] <info> [src/camera_realsense.cpp:670] recommended firmware: 5.16.0.1

6/26/2025, 4:47:55 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 16:47:55: [Viam C++ SDK] <info> [src/camera_realsense.cpp:669] firmware: 5.16.0.1

6/26/2025, 4:47:55 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 16:47:55: [Viam C++ SDK] <info> [src/camera_realsense.cpp:667] serial: 332522076372

6/26/2025, 4:47:55 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 16:47:55: [Viam C++ SDK] <info> [src/camera_realsense.cpp:666] name: Intel RealSense D435

6/26/2025, 4:47:55 PM info rdk.modmanager.local-irs.StdOut   pexec/managed_process.go:398   \_ 2025--06--26 16:47:55: [Viam C++ SDK] <info> [src/camera_realsense.cpp:1055] [start_rs2_sdk] detected connected device [1 out of 2]:
```

## 2 cameras plugged in...
### Unplug 1
```
6/26/2025, 3:29:14 PM info Viam C++ SDK     [src/camera_realsense.cpp:833] [device_changed] device removed event for S/N: 332522076372   log_ts 2025-06-26T15:29:14.374Z

6/26/2025, 3:29:14 PM info Viam C++ SDK     [src/camera_realsense.cpp:829] [device_changed] global device changed event received.   log_ts 2025-06-26T15:29:14.373Z
```

### Plug it back in really fast (not much time elapsed between disconnect and reconnect events)
```
6/26/2025, 3:29:17 PM info Viam C++ SDK     [src/camera_realsense.cpp:669] firmware: 5.16.0.1   log_ts 2025-06-26T15:29:17.532Z

6/26/2025, 3:29:17 PM info Viam C++ SDK     [src/camera_realsense.cpp:667] serial: 332522076372   log_ts 2025-06-26T15:29:17.532Z

6/26/2025, 3:29:17 PM info Viam C++ SDK     [src/camera_realsense.cpp:666] name: Intel RealSense D435   log_ts 2025-06-26T15:29:17.531Z

6/26/2025, 3:29:17 PM info Viam C++ SDK     [src/camera_realsense.cpp:725] starting pipeline with device:   log_ts 2025-06-26T15:29:17.531Z

6/26/2025, 3:29:17 PM error Viam C++ SDK     [src/camera_realsense.cpp:921] waiting for frameLoop to stop in on_device_reconnect   log_ts 2025-06-26T15:29:17.233Z

6/26/2025, 3:29:17 PM error Viam C++ SDK     [src/camera_realsense.cpp:921] waiting for frameLoop to stop in on_device_reconnect   log_ts 2025-06-26T15:29:17.222Z

6/26/2025, 3:29:17 PM error Viam C++ SDK     [src/camera_realsense.cpp:921] waiting for frameLoop to stop in on_device_reconnect   log_ts 2025-06-26T15:29:17.210Z

6/26/2025, 3:29:16 PM warn viam-agent     unstructured output: i16 v,h,dc,p: 21% 28% 29% 22% x264 [info]: i8c dc,h,v,p: 49% 26% 20% 6% x264 [info]: kb/s:3056.13

6/26/2025, 3:29:16 PM warn viam-agent     unstructured output: x264 [info]: frame I:6 Avg QP:21.00 size: 62857 x264 [info]: frame P:106 Avg QP:22.74 size: 12588 x264 [info]: mb I I16..4: 100.0% 0.0% 0.0% x264 [info]: mb P I16..4: 7.6% 0.0% 0.0% P16..4: 61.4% 0.0% 0.0% 0.0% 0.0% skip:30.9% x264 [info]: coded y,uvDC,uvAC intra: 36.6% 52.4% 4.0% inter: 16.2% 45.6% 0.2% x264 [info]:

6/26/2025, 3:29:16 PM warn viam-agent     unstructured output: x264 [info]: mb P I16..4: 11.7% 0.0% 0.0% P16..4: 39.8% 0.0% 0.0% 0.0% 0.0% skip:48.4% x264 [info]: coded y,uvDC,uvAC intra: 29.1% 44.2% 5.5% inter: 14.4% 24.6% 1.9% x264 [info]: i16 v,h,dc,p: 26% 44% 19% 10% x264 [info]: i8c dc,h,v,p: 51% 25% 18% 6% x264 [info]: kb/s:968.69

6/26/2025, 3:29:16 PM warn viam-agent     unstructured output: x264 [info]: frame I:6 Avg QP:18.00 size: 26068 x264 [info]: frame P:106 Avg QP:18.61 size: 3642 x264 [info]: mb I I16..4: 100.0% 0.0% 0.0%

6/26/2025, 3:29:16 PM info rdk   stream/server.go:257   Removing video stream   name irs-2  peerConn 0xc000597188

6/26/2025, 3:29:16 PM info rdk   stream/server.go:257   Removing video stream   name irs-1  peerConn 0xc000597188

6/26/2025, 3:29:16 PM info Viam C++ SDK     [src/camera_realsense.cpp:919] waiting for frameLoop to stop in on_device_reconnect   log_ts 2025-06-26T15:29:16.230Z

6/26/2025, 3:29:16 PM info Viam C++ SDK     [src/camera_realsense.cpp:919] waiting for frameLoop to stop in on_device_reconnect   log_ts 2025-06-26T15:29:16.219Z

6/26/2025, 3:29:16 PM info Viam C++ SDK     [src/camera_realsense.cpp:919] waiting for frameLoop to stop in on_device_reconnect   log_ts 2025-06-26T15:29:16.209Z

6/26/2025, 3:29:16 PM info Viam C++ SDK     [src/camera_realsense.cpp:910] [on_device_reconnect] Processing reconnect for device with configured S/N: 332522076372   log_ts 2025-06-26T15:29:16.209Z

6/26/2025, 3:29:16 PM info Viam C++ SDK     [src/camera_realsense.cpp:883] [device_changed] matching active device found for S/N: 332522076372. Scheduling reconnect.   log_ts 2025-06-26T15:29:16.208Z

6/26/2025, 3:29:16 PM info Viam C++ SDK     [src/camera_realsense.cpp:865] [device_changed] device added event for S/N: 332522076372   log_ts 2025-06-26T15:29:16.208Z

6/26/2025, 3:29:16 PM info Viam C++ SDK     [src/camera_realsense.cpp:829] [device_changed] global device changed event received.   log_ts 2025-06-26T15:29:16.187Z
```
We wait for the frameLoop to stop on reconnect, and then get a successful startPipeline log output.

## 2 cameras plugged in part 2
### Unplug one, then wait ~15 seconds to replug
```
6/26/2025, 3:32:37 PM info Viam C++ SDK     [src/camera_realsense.cpp:669] firmware: 5.16.0.1   log_ts 2025-06-26T15:32:37.225Z

6/26/2025, 3:32:37 PM info Viam C++ SDK     [src/camera_realsense.cpp:667] serial: 332522076372   log_ts 2025-06-26T15:32:37.224Z

6/26/2025, 3:32:37 PM info Viam C++ SDK     [src/camera_realsense.cpp:666] name: Intel RealSense D435   log_ts 2025-06-26T15:32:37.224Z

6/26/2025, 3:32:37 PM info Viam C++ SDK     [src/camera_realsense.cpp:725] starting pipeline with device:   log_ts 2025-06-26T15:32:37.223Z

6/26/2025, 3:32:37 PM warn Viam C++ SDK     [src/camera_realsense.cpp:519] [frameLoop] Exception stopping pipeline: stop() cannot be called before start()   log_ts 2025-06-26T15:32:37.151Z

6/26/2025, 3:32:37 PM error Viam C++ SDK     Message logged 44 times in past 1m0s: [src/camera_realsense.cpp:921] waiting for frameLoop to stop in on_device_reconnect   log_ts 2025-06-26T15:32:37.144Z

6/26/2025, 3:32:37 PM info Viam C++ SDK     Message logged 199 times in past 1m0s: [src/camera_realsense.cpp:919] waiting for frameLoop to stop in on_device_reconnect   log_ts 2025-06-26T15:32:37.144Z

6/26/2025, 3:32:36 PM error Viam C++ SDK     [src/camera_realsense.cpp:921] waiting for frameLoop to stop in on_device_reconnect   log_ts 2025-06-26T15:32:36.686Z

6/26/2025, 3:32:36 PM error Viam C++ SDK     [src/camera_realsense.cpp:921] waiting for frameLoop to stop in on_device_reconnect   log_ts 2025-06-26T15:32:36.675Z

6/26/2025, 3:32:36 PM error Viam C++ SDK     [src/camera_realsense.cpp:921] waiting for frameLoop to stop in on_device_reconnect   log_ts 2025-06-26T15:32:36.664Z

6/26/2025, 3:32:35 PM info Viam C++ SDK     [src/camera_realsense.cpp:910] [on_device_reconnect] Processing reconnect for device with configured S/N: 332522076372   log_ts 2025-06-26T15:32:35.660Z

6/26/2025, 3:32:35 PM info Viam C++ SDK     [src/camera_realsense.cpp:883] [device_changed] matching active device found for S/N: 332522076372. Scheduling reconnect.   log_ts 2025-06-26T15:32:35.659Z

6/26/2025, 3:32:35 PM info Viam C++ SDK     [src/camera_realsense.cpp:865] [device_changed] device added event for S/N: 332522076372   log_ts 2025-06-26T15:32:35.659Z

6/26/2025, 3:32:19 PM info Viam C++ SDK     [src/camera_realsense.cpp:833] [device_changed] device removed event for S/N: 332522076372   log_ts 2025-06-26T15:32:19.153Z

6/26/2025, 3:32:19 PM info Viam C++ SDK     [src/camera_realsense.cpp:829] [device_changed] global device changed event received.   log_ts 2025-06-26T15:32:19.153Z
```
We get this bad error about stop() being called before start(). This is expected because there is an existing bug that does not stop the frameLoop when the underlying camera is disconnected. Not this PR's responsibility to fix this. However, we do see the logs we want to see! Yay.

