### PR TITLE
Lowering get_point_cloud log message to debug from info

### DIFF
--- a/src/module/realsense.hpp
+++ b/src/module/realsense.hpp
@@ -431,7 +431,7 @@ public:
         VIAM_SDK_LOG(error) << "[get_point_cloud] no frameset available";
         throw std::runtime_error("no frameset available");
       }
-      VIAM_SDK_LOG(info) << "[get_point_cloud] start";
+      VIAM_SDK_LOG(debug) << "[get_point_cloud] start";
       auto fs = latest_frameset_->get();
 
       double nowMs = time::getNowMs();
@@ -486,7 +486,7 @@ public:
                                  std::to_string(MAX_GRPC_MESSAGE_SIZE));
       }
 
-      VIAM_SDK_LOG(info) << "[get_point_cloud] end";
+      VIAM_SDK_LOG(debug) << "[get_point_cloud] end";
       return viam::sdk::Camera::point_cloud{kPcdMimeType, data};
     } catch (const std::exception &e) {
       VIAM_SDK_LOG(error) << "[get_point_cloud] error: " << e.what();


### PR DESCRIPTION
Avoiding these log messages
```
9/17/2025, 1:48:20 PM info Viam C++ SDK     [module/realsense.hpp:509] [get_point_cloud] end   log_ts 2025-09-17T13:48:20.881Z

9/17/2025, 1:48:20 PM info Viam C++ SDK     [module/realsense.hpp:454] [get_point_cloud] start   log_ts 2025-09-17T13:48:20.846Z

9/17/2025, 1:48:18 PM info Viam C++ SDK     [module/realsense.hpp:509] [get_point_cloud] end   log_ts 2025-09-17T13:48:18.019Z

9/17/2025, 1:48:17 PM info Viam C++ SDK     [module/realsense.hpp:454] [get_point_cloud] start   log_ts 2025-09-17T13:48:17.985Z

9/17/2025, 1:48:14 PM info Viam C++ SDK     [module/realsense.hpp:509] [get_point_cloud] end   log_ts 2025-09-17T13:48:14.932Z

9/17/2025, 1:48:14 PM info Viam C++ SDK     [module/realsense.hpp:454] [get_point_cloud] start   log_ts 2025-09-17T13:48:14.898Z

9/17/2025, 1:48:11 PM info Viam C++ SDK     Message logged 25 times in past 1m0s: [module/realsense.hpp:509] [get_point_cloud] end   log_ts 2025-09-17T13:48:11.881Z

9/17/2025, 1:48:11 PM info Viam C++ SDK     Message logged 25 times in past 1m0s: [module/realsense.hpp:454] [get_point_cloud] start   log_ts 2025-09-17T13:48:11.847Z

9/17/2025, 1:47:16 PM info Viam C++ SDK     [module/realsense.hpp:509] [get_point_cloud] end   log_ts 2025-09-17T13:47:16.890Z

9/17/2025, 1:47:16 PM info Viam C++ SDK     [module/realsense.hpp:454] [get_point_cloud] start   log_ts 2025-09-17T13:47:16.857Z

9/17/2025, 1:47:14 PM info Viam C++ SDK     [module/realsense.hpp:509] [get_point_cloud] end   log_ts 2025-09-17T13:47:14.899Z

9/17/2025, 1:47:14 PM info Viam C++ SDK     [module/realsense.hpp:454] [get_point_cloud] start   log_ts 2025-09-17T13:47:14.865Z

9/17/2025, 1:47:12 PM info Viam C++ SDK     [module/realsense.hpp:509] [get_point_cloud] end   log_ts 2025-09-
```